### PR TITLE
Use textContent instead of innerText when possible

### DIFF
--- a/code.js
+++ b/code.js
@@ -6,7 +6,11 @@ var current = -1;
 function updateCurrent() {
 	var im = document.getElementById("image");
 	if (current >= 0) {
-		document.getElementById("current_id").innerText = current+" ("+list[current]+")";
+		var element = document.getElementById("current_id");
+		if (element.textContent != undefined)
+			element.textContent = current+" ("+list[current]+")";
+		else
+			element.innerText = current+" ("+list[current]+")";
 		im.src = "img/"+list[current];
 	}
 }


### PR DESCRIPTION
innerText is an IE thing. textContent is supported on all modern versions of major browsers.
More information: https://developer.mozilla.org/en-US/docs/Web/API/Node.textContent

This fix will also (hopefully, as I don't have any machine where IE is older than 9 to test) fallback to innerText on older versions  of IE.

Fixes issue #2
